### PR TITLE
Fix escaping of messages

### DIFF
--- a/views/_message.haml
+++ b/views/_message.haml
@@ -20,6 +20,6 @@
   - elsif message.me_tell?
     = message.nick
 
-  = format_message(message.line, (@nicks if message.talk?))
+  != format_message(escape_html(message.line), (@nicks if message.talk?))
 
   %br


### PR DESCRIPTION
`format_message` returns HTML fragments and should not be escaped again.